### PR TITLE
Emit failed tests' output

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ pub struct TestResult {
     pub iterations: u16,
     pub successes: u16,
     pub failures: u16,
-    pub failure_output: Vec<String>
+    pub failure_output: Vec<u8>
 }
 
 impl TestResult {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@ pub struct TestResult {
     pub iterations: u16,
     pub successes: u16,
     pub failures: u16,
+    pub failure_output: Vec<String>
 }
 
 impl TestResult {
@@ -92,6 +93,7 @@ impl TestResult {
             iterations: 0,
             successes: 0,
             failures: 0,
+            failure_output: Vec::new()
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ pub fn get_test_names(config: &FlakeConfig) -> Result<Vec<String>, std::io::Erro
 pub fn run_single_test(setup: TestSetup) -> Result<TestResult, std::io::Error> {
     let mut result = TestResult::new(setup.name);
     for _ in 0..(setup.iterations as usize) {
-        let output = Command::new("sh")
+        let mut output = Command::new("sh")
             .arg("-c")
             .arg(&setup.command)
             .output()
@@ -31,9 +31,7 @@ pub fn run_single_test(setup: TestSetup) -> Result<TestResult, std::io::Error> {
         if output.status.success() {
             result.successes += 1;
         } else {
-            result
-                .failure_output
-                .push(String::from_utf8(output.stdout).unwrap());
+            result.failure_output.append(&mut output.stdout);
             result.failures += 1;
         }
     }


### PR DESCRIPTION
To keep progress bar intact, I updated the TestResult to hold a vector of the collected failed test output.

Similarly to parsing the test names, I figure the output can be parsed so the entire output isn't emitted at the end.

Closes #7 